### PR TITLE
 chore(github): update PR template to highlight LTS mode

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+# AngularJS is in LTS mode
+We are no longer accepting changes that are not critical bug fixes into this project.
+See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.
+
 <!--
 IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOUT INVESTIGATION
 -->
@@ -9,8 +13,9 @@ IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOU
 
 **I'm submitting a ...**
 <!-- (check one with "x") -->
-- [ ] bug report
-- [ ] feature request
+- [ ] regression from 1.7.0
+- [ ] security issue
+- [ ] issue caused by a new browser version
 - [ ] other <!--(Please do not submit support requests here - see above)-->
 
 **Current behavior:**
@@ -26,7 +31,7 @@ please provide the *STEPS TO REPRODUCE* and if possible a *MINIMAL DEMO* of the 
 https://plnkr.co or similar (you can use this template as a starting point: http://plnkr.co/edit/tpl:yBpEi4).
 -->
 
-**AngularJS version:** 1.x.y
+**AngularJS version:** 1.7.x
 <!-- Check whether this is still an issue in the most recent stable or in the snapshot AngularJS
 version (https://code.angularjs.org/snapshot/) -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,11 @@
-<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
-**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
+# AngularJS is in LTS mode
+We are no longer accepting changes that are not critical bug fixes into this project.
+See https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c for more detail.
 
+<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
+**Does this PR fix a regression since 1.7.0, a security flaw, or a problem caused by a new browser version?**
+
+<!-- If the answer is no, then we will not merge this PR -->
 
 
 **What is the current behavior? (You can also link to an open issue here)**


### PR DESCRIPTION
<!-- General PR submission guidelines https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#submit-pr -->
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our [guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
- [ ] Fix/Feature: [Docs](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#documentation) have been added/updated
- [ ] Fix/Feature: Tests have been added; existing tests pass

**Other information**:

